### PR TITLE
chore: remove pins for django and wagtail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octave-styleguide"
-version = "1.0.0"
+version = "1.0.1"
 description = "Easily add shortcut icons to any wagtail site."
 authors = ["Pat Horsley <pat@octave.nz>"]
 readme = 'README.md'
@@ -8,8 +8,6 @@ license = "BSD"
 
 [tool.poetry.dependencies]
 python = "^3"
-Django = "^2.2"
-wagtail = "^2.8"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Removes pins for django and wagtail to allow new django and wagtail versions in wagtail start
bumps version to 1.0.1